### PR TITLE
mark Rails as development dependency

### DIFF
--- a/devise-pwned_password.gemspec
+++ b/devise-pwned_password.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.1.2"
   s.add_dependency "devise", "~> 4"
 
+  s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Rails is only required in unit tests so it can be a development dependency and not required by users installing this gem.