### PR TITLE
Fail silently for Net::HTTP exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ a certain number of times in the data set:
 config.min_password_matches = 10
 ```
 
+By default responses from the PwnedPasswords API are timed out after 5 seconds
+to reduce potential latency problems.
+Optionally, you can add the following snippet to `config/initializers/devise.rb`
+to control the timeout settings:
+
+```ruby
+config.pwned_password_open_timeout = 1
+config.pwned_password_read_timeout = 2
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/lib/devise/pwned_password.rb
+++ b/lib/devise/pwned_password.rb
@@ -4,8 +4,10 @@ require "devise"
 require "devise/pwned_password/model"
 
 module Devise
-  mattr_accessor :min_password_matches
+  mattr_accessor :min_password_matches, :pwned_password_open_timeout, :pwned_password_read_timeout
   @@min_password_matches = 1
+  @@pwned_password_open_timeout = 5
+  @@pwned_password_read_timeout = 5
 
   module PwnedPassword
   end


### PR DESCRIPTION
Some of the most common exceptions Net::HTTP
requests raise are Timeout::Error, Errno::ECONNRESET
and Net::HTTPBadResponse. Those are now ignored and
do not prevent signing up.

The default Net::HTTP timeout setting for open
and read is 60 seconds, which is too long to block
a sign up for, so more reasonable defaults are set
with the option to override them.