### PR TITLE
Fix “no implicit conversion of nil into String”

### DIFF
--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -13,7 +13,7 @@ module Devise
       extend ActiveSupport::Concern
 
       included do
-        validate :not_pwned_password
+        validate :not_pwned_password, if: :password_required?
       end
 
       module ClassMethods


### PR DESCRIPTION
If the devise model is :trackable, the model will be updated and saved at which point validations are run. However password is cleared on authentication so `Digest::SHA1.hexdigest(password).upcase` fails because password is nil. Add a guard clause to prevent the validation from running if the password isn’t present.