### PR TITLE
Handle nil password edgecase

### DIFF
--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -31,7 +31,7 @@ module Devise
       # Implement retry behaviour described here https://haveibeenpwned.com/API/v2#RateLimiting
       def password_pwned?(password)
         @pwned = false
-        hash = Digest::SHA1.hexdigest(password).upcase
+        hash = Digest::SHA1.hexdigest(password.to_s).upcase
         prefix, suffix = hash.slice!(0..4), hash
 
         userAgent = "devise_pwned_password"


### PR DESCRIPTION
If a nil password is somehow submitted (tests, api style signup) an exception is currently
thrown instead of allowing the rest of the validations to run.