### PR TITLE
💎 bumps Rails dependency to 5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ PLATFORMS
 DEPENDENCIES
   devise (~> 4)
   devise-pwned_password!
-  rails (~> 5.1.2)
+  rails (< 5.3)
   rubocop (~> 0.52.1)
   sqlite3
 

--- a/devise-pwned_password.gemspec
+++ b/devise-pwned_password.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "devise", "~> 4"
 
-  s.add_development_dependency "rails", "~> 5.1.2"
+  s.add_development_dependency "rails", "< 5.3"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rubocop", "~> 0.52.1"
 end


### PR DESCRIPTION
wanted to use this in my app, but I'm using the Rails 5.2 RC and the current gemspec didn't support it. I went ahead and set the dependency to be <5.3 so that it could be successfully installed. It also looks like all the tests still pass, so I thought I'd share!