### PR TITLE
Expose pwned_count on the devise resource

### DIFF
--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -27,10 +27,16 @@ module Devise
         @pwned ||= false
       end
 
+      def pwned_count
+        @pwned_count ||= 0
+      end
+
       # Returns true if password is present in the PwnedPasswords dataset
       # Implement retry behaviour described here https://haveibeenpwned.com/API/v2#RateLimiting
       def password_pwned?(password)
         @pwned = false
+        @pwned_count = 0
+
         options = {
           "User-Agent" => "devise_pwned_password",
           read_timeout: self.class.pwned_password_read_timeout,
@@ -38,7 +44,8 @@ module Devise
         }
         pwned_password = Pwned::Password.new(password.to_s, options)
         begin
-          @pwned = pwned_password.pwned_count >= self.class.min_password_matches
+          @pwned_count = pwned_password.pwned_count
+          @pwned = @pwned_count >= self.class.min_password_matches
           return @pwned
         rescue Pwned::Error
           return false

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -4,13 +4,28 @@ require "test_helper"
 
 class Devise::PwnedPassword::Test < ActiveSupport::TestCase
   test "should deny validation for a pwned password" do
-    user = User.create email: "example@example.org", password: "password", password_confirmation: "password"
+    password = "password"
+    user = User.create email: "example@example.org", password: password, password_confirmation: password
     assert_not user.valid?, "User with pwned password shoud not be valid."
   end
+
   test "should accept validation for a password not in the dataset" do
     # This test will be unavoidably flaky
     password = "fddkasnsdddghjt"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
     assert user.valid?, "User with password not in the dataset should be valid."
+  end
+
+  test "should return a non-zero count for a pwned password" do
+    password = "password"
+    user = User.create email: "example@example.org", password: password, password_confirmation: password
+    assert_not_equal user.pwned_count, 0, "User with pwned password should not have a zero count."
+  end
+
+  test "should return a count of zero for a password not in the dataset" do
+    # This test will be unavoidably flaky
+    password = "fddkasnsdddghjt"
+    user = User.create email: "example@example.org", password: password, password_confirmation: password
+    assert_equal user.pwned_count, 0, "User with password not in the dataset should have a zero count."
   end
 end


### PR DESCRIPTION
I wanted to be able to record how many matches my users (employees in my case) passwords were returning, but found that information is not a available on the resource after validation, so I've added a new `pwned_count` method to the model which makes the count of matches available on the devise resource (eg. User). I have also added some simple tests.

This method currently defaults to zero, in keeping with the initial false value for `.pwned?`.

I considered updating the README to show this being used in the flash message, but then got into thinking about properly pluralising the locales file, and whether it's even a good idea to encourage showing the count publicly. Happy to add this as a new section if you think it'll be useful.

Thanks!