### PR TITLE
Optionally set a different password match threshold to warn users

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ a certain number of times in the data set:
 config.min_password_matches = 10
 ```
 
+By default the value set above is used to reject passwords and warn users.
+Optionally, you can add the following snippet to `config/initializers/devise.rb`
+if you want to use different thresholds for rejecting the password and warning
+the user (for example you may only want to reject passwords that are common but
+warn if the password occurs at all in the list):
+
+```ruby
+# Minimum number of times a pwned password must exist in the data set in order
+# to warn the user.
+config.min_password_matches_warn = 1
+```
+
 By default responses from the PwnedPasswords API are timed out after 5 seconds
 to reduce potential latency problems.
 Optionally, you can add the following snippet to `config/initializers/devise.rb`

--- a/lib/devise/pwned_password.rb
+++ b/lib/devise/pwned_password.rb
@@ -4,8 +4,9 @@ require "devise"
 require "devise/pwned_password/model"
 
 module Devise
-  mattr_accessor :min_password_matches, :pwned_password_open_timeout, :pwned_password_read_timeout
+  mattr_accessor :min_password_matches, :min_password_matches_warn, :pwned_password_open_timeout, :pwned_password_read_timeout
   @@min_password_matches = 1
+  @@min_password_matches_warn = nil
   @@pwned_password_open_timeout = 5
   @@pwned_password_read_timeout = 5
 

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -19,6 +19,7 @@ module Devise
 
       module ClassMethods
         Devise::Models.config(self, :min_password_matches)
+        Devise::Models.config(self, :min_password_matches_warn)
         Devise::Models.config(self, :pwned_password_open_timeout)
         Devise::Models.config(self, :pwned_password_read_timeout)
       end
@@ -45,7 +46,7 @@ module Devise
         pwned_password = Pwned::Password.new(password.to_s, options)
         begin
           @pwned_count = pwned_password.pwned_count
-          @pwned = @pwned_count >= self.class.min_password_matches
+          @pwned = @pwned_count >= (persisted? ? self.class.min_password_matches_warn || self.class.min_password_matches : self.class.min_password_matches)
           return @pwned
         rescue Pwned::Error
           return false

--- a/test/dummy/config/initializers/devise.rb
+++ b/test/dummy/config/initializers/devise.rb
@@ -278,4 +278,8 @@ Devise.setup do |config|
   # Minimum number of times a pwned password must exist in the data set in order
   # to be reject.
   # config.min_password_matches = 1
+
+  # Minimum number of times a pwned password must exist in the data set in order
+  # to warn the user.
+  # config.min_password_matches_warn = 1
 end


### PR DESCRIPTION
You may want to treat pwned passwords differently for new users vs existing users.

For example you may only want to reject passwords on sign up that are common (`min_password_matches = 1000`) but then still warn users if their password occurs at all in the list giving them the option to choose a better password.

If you do choose to have a different warning threshold, that threshold should then be used when a users changes their password so that they don't continue to be warned if they choose another password that is in the pwned list (but occurs with a frequency below the sign up threshold).