### PR TITLE
Updates to Pwned version 2

### DIFF
--- a/devise-pwned_password.gemspec
+++ b/devise-pwned_password.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "devise", "~> 4"
-  s.add_dependency "pwned", "~> 1.2.1"
+  s.add_dependency "pwned", "~> 2.0.0"
 
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -33,7 +33,6 @@ module Devise
       end
 
       # Returns true if password is present in the PwnedPasswords dataset
-      # Implement retry behaviour described here https://haveibeenpwned.com/API/v2#RateLimiting
       def password_pwned?(password)
         @pwned = false
         @pwned_count = 0

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -38,7 +38,7 @@ module Devise
         @pwned_count = 0
 
         options = {
-          "User-Agent" => "devise_pwned_password",
+          headers: { "User-Agent" => "devise_pwned_password" },
           read_timeout: self.class.pwned_password_read_timeout,
           open_timeout: self.class.pwned_password_open_timeout
         }


### PR DESCRIPTION
Pwned v2 mostly is an under the hood change from open-uri to Net::Http. The one breaking change is sending headers through the request. They now should be set using the  key in the options hash.