### PR TITLE
Only check for pwned password if pwned_password_check_on_sign_in is set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,14 +107,7 @@ And then execute:
 $ bundle install
 ```
 
-Optionally, if you also want to warn existing users when they sign in, add the following to `config/initializers/devise.rb`:
-
-```ruby
-config.pwned_password_check_on_sign_in = true
-```
-
-and override `after_sign_in_path_for`
-
+Optionally, if you also want to warn existing users when they sign in, override `after_sign_in_path_for`
 ```ruby
 def after_sign_in_path_for(resource)
   set_flash_message! :alert, :warn_pwned if resource.respond_to?(:pwned?) && resource.pwned?
@@ -134,6 +127,11 @@ class ActiveAdmin::Devise::SessionsController
 end
 ```
 
+To prevent the default call to the HaveIBeenPwned API on user sign in, add the following to `config/initializers/devise.rb`:
+
+```ruby
+config.pwned_password_check_on_sign_in = false
+```
 
 ## Considerations
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,14 @@ And then execute:
 $ bundle install
 ```
 
-Optionally, if you also want to warn existing users when they sign in, override `after_sign_in_path_for`
+Optionally, if you also want to warn existing users when they sign in, add the following to `config/initializers/devise.rb`:
+
+```ruby
+config.pwned_password_check_on_sign_in = true
+```
+
+and override `after_sign_in_path_for`
+
 ```ruby
 def after_sign_in_path_for(resource)
   set_flash_message! :alert, :warn_pwned if resource.respond_to?(:pwned?) && resource.pwned?

--- a/lib/devise/pwned_password.rb
+++ b/lib/devise/pwned_password.rb
@@ -8,7 +8,7 @@ module Devise
                  :pwned_password_open_timeout, :pwned_password_read_timeout
   @@min_password_matches = 1
   @@min_password_matches_warn = nil
-  @@pwned_password_check_on_sign_in = false
+  @@pwned_password_check_on_sign_in = true
   @@pwned_password_open_timeout = 5
   @@pwned_password_read_timeout = 5
 

--- a/lib/devise/pwned_password.rb
+++ b/lib/devise/pwned_password.rb
@@ -4,9 +4,11 @@ require "devise"
 require "devise/pwned_password/model"
 
 module Devise
-  mattr_accessor :min_password_matches, :min_password_matches_warn, :pwned_password_open_timeout, :pwned_password_read_timeout
+  mattr_accessor :min_password_matches, :min_password_matches_warn, :pwned_password_check_on_sign_in,
+                 :pwned_password_open_timeout, :pwned_password_read_timeout
   @@min_password_matches = 1
   @@min_password_matches_warn = nil
+  @@pwned_password_check_on_sign_in = false
   @@pwned_password_open_timeout = 5
   @@pwned_password_read_timeout = 5
 

--- a/lib/devise/pwned_password/hooks/pwned_password.rb
+++ b/lib/devise/pwned_password/hooks/pwned_password.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Warden::Manager.after_set_user except: :fetch do |user, auth, opts|
-  password = auth.request.params.fetch(opts[:scope], {}).fetch(:password, nil)
-  password && auth.authenticated?(opts[:scope]) && user.respond_to?(:password_pwned?) && user.password_pwned?(password)
+  if user.class.respond_to?(:pwned_password_check_on_sign_in) && user.class.pwned_password_check_on_sign_in
+    password = auth.request.params.fetch(opts[:scope], {}).fetch(:password, nil)
+    password && auth.authenticated?(opts[:scope]) && user.respond_to?(:password_pwned?) && user.password_pwned?(password)
+  end
 end

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -20,6 +20,7 @@ module Devise
       module ClassMethods
         Devise::Models.config(self, :min_password_matches)
         Devise::Models.config(self, :min_password_matches_warn)
+        Devise::Models.config(self, :pwned_password_check_on_sign_in)
         Devise::Models.config(self, :pwned_password_open_timeout)
         Devise::Models.config(self, :pwned_password_read_timeout)
       end


### PR DESCRIPTION
Avoid calls to haveibeenpwned API on user login by default for when we don't want to warn existing users that their password is compromised.