### PR TITLE
Pass count to error message

### DIFF
--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -58,9 +58,9 @@ module Devise
       private
 
         def not_pwned_password
-          # This deliberately fails silently on 500's etc. Most apps wont want to tie the ability to sign up customers to the availability of a third party API
+          # This deliberately fails silently on 500's etc. Most apps won't want to tie the ability to sign up users to the availability of a third-party API.
           if password_pwned?(password)
-            errors.add(:password, :pwned_password)
+            errors.add(:password, :pwned_password, count: @pwned_count)
           end
         end
     end

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -7,6 +7,19 @@ class Devise::PwnedPassword::Test < ActiveSupport::TestCase
     password = "password"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
     assert_not user.valid?, "User with pwned password shoud not be valid."
+    assert_match /\Ahas appeared in a data breach \d{7,} times\z/, user.errors[:password].first
+  end
+
+  test "should deny validation for a pwned password: {count: 1}" do
+    password = "password"
+    user = User.create email: "example@example.org", password: password, password_confirmation: password
+    pwned_password = Minitest::Mock.new
+    pwned_password.expect :pwned_count, 1
+    Pwned::Password.stub :new, pwned_password do
+      assert_not user.valid?, "User with pwned password shoud not be valid."
+    end
+    assert_match "has appeared in a data breach", user.errors[:password].first
+    pwned_password.verify
   end
 
   test "should accept validation for a password not in the dataset" do

--- a/test/dummy/config/locales/devise.en.yml
+++ b/test/dummy/config/locales/devise.en.yml
@@ -62,3 +62,6 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      pwned_password:
+        one:   "has appeared in a data breach"
+        other: "has appeared in a data breach %{count} times"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 require "rails/test_help"
 
+require 'minitest/mock'
+
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new


### PR DESCRIPTION
I'd like to be able to include the number of breaches in my custom error message, something like this:

```
      pwned_password:
        one:   "has appeared in a data breach"
        other: "has appeared in a data breach %{count} times"
```

The fantastic [`not_pwned` validator](https://github.com/philnash/pwned/blob/master/lib/pwned/not_pwned_validator.rb) from `pwned` gem passes `count` to the error message; we should do that too! It's too bad we're not just using `:not_pwned` validator in this gem; this library ends up having to duplicate some things as a result, uses a different API, etc.

Note that the `count` interpolation key is optional to use: you don't have to use it in your message (and you don't have to split the message into `one` and `other` either), but it's available to use if you want it now.