### PR TITLE
Add missing tests for User.min_password_matches_warn

### DIFF
--- a/devise-pwned_password.gemspec
+++ b/devise-pwned_password.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rubocop", "~> 0.52.1"
+  s.add_development_dependency "byebug"
 end

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -46,7 +46,13 @@ module Devise
         pwned_password = Pwned::Password.new(password.to_s, options)
         begin
           @pwned_count = pwned_password.pwned_count
-          @pwned = @pwned_count >= (persisted? ? self.class.min_password_matches_warn || self.class.min_password_matches : self.class.min_password_matches)
+          @pwned = @pwned_count >= (
+            if persisted?
+              self.class.min_password_matches_warn || self.class.min_password_matches
+            else
+                                                      self.class.min_password_matches
+            end
+          )
           return @pwned
         rescue Pwned::Error
           return false

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -58,9 +58,9 @@ module Devise
       private
 
         def not_pwned_password
-          # This deliberately fails silently on 500's etc. Most apps wont want to tie the ability to sign up customers to the availability of a third party API
+          # This deliberately fails silently on 500's etc. Most apps won't want to tie the ability to sign up users to the availability of a third-party API.
           if password_pwned?(password)
-            errors.add(:password, :pwned_password)
+            errors.add(:password, :pwned_password, count: @pwned_count)
           end
         end
     end

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -7,6 +7,19 @@ class Devise::PwnedPassword::Test < ActiveSupport::TestCase
     password = "password"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
     assert_not user.valid?, "User with pwned password shoud not be valid."
+    assert_match /\Ahas appeared in a data breach \d{7,} times\z/, user.errors[:password].first
+  end
+
+  test "should deny validation for a pwned password: {count: 1}" do
+    password = "password"
+    user = User.create email: "example@example.org", password: password, password_confirmation: password
+    pwned_password = Minitest::Mock.new
+    pwned_password.expect :pwned_count, 1
+    Pwned::Password.stub :new, pwned_password do
+      assert_not user.valid?, "User with pwned password shoud not be valid."
+    end
+    assert_match "has appeared in a data breach", user.errors[:password].first
+    pwned_password.verify
   end
 
   test "should accept validation for a password not in the dataset" do

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -3,42 +3,63 @@
 require "test_helper"
 
 class Devise::PwnedPassword::Test < ActiveSupport::TestCase
-  test "should deny validation for a pwned password" do
-    password = "password"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert_not user.valid?, "User with pwned password shoud not be valid."
-    assert_match /\Ahas appeared in a data breach \d{7,} times\z/, user.errors[:password].first
+  def setup
+    User.min_password_matches = 1
+    User.min_password_matches_warn = nil
   end
 
-  test "should deny validation for a pwned password: {count: 1}" do
-    password = "password"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    pwned_password = Minitest::Mock.new
-    pwned_password.expect :pwned_count, 1
-    Pwned::Password.stub :new, pwned_password do
-      assert_not user.valid?, "User with pwned password shoud not be valid."
+  class WhenPwned < Devise::PwnedPassword::Test
+    test "should deny validation and set pwned_count" do
+      user = pwned_password_user
+      assert_not user.valid?
+      assert_match /\Ahas appeared in a data breach \d{7,} times\z/, user.errors[:password].first
+      assert user.pwned_count > 0
     end
-    assert_match "has appeared in a data breach", user.errors[:password].first
-    pwned_password.verify
+
+    test "when pwned_count < min_password_matches, is considered valid" do
+      user = pwned_password_user
+      User.min_password_matches = 999_999_999
+      assert user.valid?
+      assert user.pwned_count > 0
+    end
   end
 
-  test "should accept validation for a password not in the dataset" do
-    # This test will be unavoidably flaky
-    password = "fddkasnsdddghjt"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert user.valid?, "User with password not in the dataset should be valid."
+  class WhenNotPwned < Devise::PwnedPassword::Test
+    test "should accept validation and set pwned_count" do
+      user = valid_password_user
+      assert user.valid?
+      assert_equal user.pwned_count, 0
+    end
+
+    test "when password changed to a pwned password: should add error if pwned_count > min_password_matches_warn || pwned_count > min_password_matches" do
+      user = valid_password_user
+
+      # *not* pwned_count > min_password_matches_warn
+      password = "password"
+      user.update password: password, password_confirmation: password
+      User.min_password_matches_warn = 999_999_999
+      assert user.valid?
+      assert_not user.pwned_count > User.min_password_matches_warn
+
+      # pwned_count > min_password_matches_warn
+      User.min_password_matches_warn = 1
+      User.min_password_matches      = 999_999_999
+      assert_not user.valid?
+      assert user.pwned_count > User.min_password_matches_warn
+    end
   end
 
-  test "should return a non-zero count for a pwned password" do
+  def pwned_password_user
     password = "password"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert_not_equal user.pwned_count, 0, "User with pwned password should not have a zero count."
+    assert user.errors.size > 0
+    user
   end
 
-  test "should return a count of zero for a password not in the dataset" do
-    # This test will be unavoidably flaky
+  def valid_password_user
     password = "fddkasnsdddghjt"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert_equal user.pwned_count, 0, "User with password not in the dataset should have a zero count."
+    assert_equal 0, user.errors.size
+    user
   end
 end

--- a/test/dummy/config/locales/devise.en.yml
+++ b/test/dummy/config/locales/devise.en.yml
@@ -62,3 +62,6 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      pwned_password:
+        one:   "has appeared in a data breach"
+        other: "has appeared in a data breach %{count} times"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 require "rails/test_help"
 
+require 'minitest/mock'
+
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+Bundler.require :development
+
 require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 require "rails/test_help"


### PR DESCRIPTION
I didn't see any tests for `User.min_password_matches_warn` — or even `User.min_password_matches`, for that matter :grimacing: — which makes me nervous as I'm changing things because I don't want to accidentally break any existing behavior. :sweat: 

(These probably should have been included as part of #16.)

This PR was based on #28 to make my life easier (since I'm submitting a lot of PRs) but can easily be rebased as needed.