### PR TITLE
Make the docs regarding warning (warn_pwned/min_password_matches_warn) clearer

### DIFF
--- a/devise-pwned_password.gemspec
+++ b/devise-pwned_password.gemspec
@@ -21,8 +21,9 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 4"
   s.add_dependency "pwned", "~> 2.0.0"
 
-  s.add_development_dependency "rails", "~> 5.1.2"
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rubocop", "~> 0.52.1"
   s.add_development_dependency "byebug"
+  s.add_development_dependency "capybara"
+  s.add_development_dependency "rails", "~> 5.1.2"
+  s.add_development_dependency "rubocop", "~> 0.52.1"
+  s.add_development_dependency "sqlite3"
 end

--- a/devise-pwned_password.gemspec
+++ b/devise-pwned_password.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rubocop", "~> 0.52.1"
+  s.add_development_dependency "byebug"
 end

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -46,7 +46,13 @@ module Devise
         pwned_password = Pwned::Password.new(password.to_s, options)
         begin
           @pwned_count = pwned_password.pwned_count
-          @pwned = @pwned_count >= (persisted? ? self.class.min_password_matches_warn || self.class.min_password_matches : self.class.min_password_matches)
+          @pwned = @pwned_count >= (
+            if persisted?
+              self.class.min_password_matches_warn || self.class.min_password_matches
+            else
+                                                      self.class.min_password_matches
+            end
+          )
           return @pwned
         rescue Pwned::Error
           return false

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -59,6 +59,7 @@ module Devise
           )
           return @pwned
         rescue Pwned::Error
+          # This deliberately silently swallows errors and returns false (valid) if there was an error. Most apps won't want to tie the ability to sign up users to the availability of a third-party API.
           return false
         end
 
@@ -68,7 +69,6 @@ module Devise
       private
 
         def not_pwned_password
-          # This deliberately fails silently on 500's etc. Most apps won't want to tie the ability to sign up users to the availability of a third-party API.
           if password_pwned?(password)
             errors.add(:password, :pwned_password, count: @pwned_count)
           end

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -58,9 +58,9 @@ module Devise
       private
 
         def not_pwned_password
-          # This deliberately fails silently on 500's etc. Most apps wont want to tie the ability to sign up customers to the availability of a third party API
+          # This deliberately fails silently on 500's etc. Most apps won't want to tie the ability to sign up users to the availability of a third-party API.
           if password_pwned?(password)
-            errors.add(:password, :pwned_password)
+            errors.add(:password, :pwned_password, count: @pwned_count)
           end
         end
     end

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -48,6 +48,10 @@ module Devise
           @pwned_count = pwned_password.pwned_count
           @pwned = @pwned_count >= (
             if persisted?
+              # If you do have a different warning threshold, that threshold will also be used
+              # when a user changes their password so that they don't continue to be warned if they
+              # choose another password that is in the pwned list but occurs with a frequency below
+              # the main threshold that is used for *new* user registrations.
               self.class.min_password_matches_warn || self.class.min_password_matches
             else
                                                       self.class.min_password_matches

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -3,11 +3,6 @@
 require "test_helper"
 
 class Devise::PwnedPassword::Test < ActiveSupport::TestCase
-  def setup
-    User.min_password_matches = 1
-    User.min_password_matches_warn = nil
-  end
-
   class WhenPwned < Devise::PwnedPassword::Test
     test "should deny validation and set pwned_count" do
       user = pwned_password_user
@@ -47,19 +42,5 @@ class Devise::PwnedPassword::Test < ActiveSupport::TestCase
       assert_not user.valid?
       assert user.pwned_count > User.min_password_matches_warn
     end
-  end
-
-  def pwned_password_user
-    password = "password"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert user.errors.size > 0
-    user
-  end
-
-  def valid_password_user
-    password = "fddkasnsdddghjt"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert_equal 0, user.errors.size
-    user
   end
 end

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -7,6 +7,19 @@ class Devise::PwnedPassword::Test < ActiveSupport::TestCase
     password = "password"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
     assert_not user.valid?, "User with pwned password shoud not be valid."
+    assert_match /\Ahas appeared in a data breach \d{7,} times\z/, user.errors[:password].first
+  end
+
+  test "should deny validation for a pwned password: {count: 1}" do
+    password = "password"
+    user = User.create email: "example@example.org", password: password, password_confirmation: password
+    pwned_password = Minitest::Mock.new
+    pwned_password.expect :pwned_count, 1
+    Pwned::Password.stub :new, pwned_password do
+      assert_not user.valid?, "User with pwned password shoud not be valid."
+    end
+    assert_match "has appeared in a data breach", user.errors[:password].first
+    pwned_password.verify
   end
 
   test "should accept validation for a password not in the dataset" do

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -3,42 +3,63 @@
 require "test_helper"
 
 class Devise::PwnedPassword::Test < ActiveSupport::TestCase
-  test "should deny validation for a pwned password" do
-    password = "password"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert_not user.valid?, "User with pwned password shoud not be valid."
-    assert_match /\Ahas appeared in a data breach \d{7,} times\z/, user.errors[:password].first
+  def setup
+    User.min_password_matches = 1
+    User.min_password_matches_warn = nil
   end
 
-  test "should deny validation for a pwned password: {count: 1}" do
-    password = "password"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    pwned_password = Minitest::Mock.new
-    pwned_password.expect :pwned_count, 1
-    Pwned::Password.stub :new, pwned_password do
-      assert_not user.valid?, "User with pwned password shoud not be valid."
+  class WhenPwned < Devise::PwnedPassword::Test
+    test "should deny validation and set pwned_count" do
+      user = pwned_password_user
+      assert_not user.valid?
+      assert_match /\Ahas appeared in a data breach \d{7,} times\z/, user.errors[:password].first
+      assert user.pwned_count > 0
     end
-    assert_match "has appeared in a data breach", user.errors[:password].first
-    pwned_password.verify
+
+    test "when pwned_count < min_password_matches, is considered valid" do
+      user = pwned_password_user
+      User.min_password_matches = 999_999_999
+      assert user.valid?
+      assert user.pwned_count > 0
+    end
   end
 
-  test "should accept validation for a password not in the dataset" do
-    # This test will be unavoidably flaky
-    password = "fddkasnsdddghjt"
-    user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert user.valid?, "User with password not in the dataset should be valid."
+  class WhenNotPwned < Devise::PwnedPassword::Test
+    test "should accept validation and set pwned_count" do
+      user = valid_password_user
+      assert user.valid?
+      assert_equal user.pwned_count, 0
+    end
+
+    test "when password changed to a pwned password: should add error if pwned_count > min_password_matches_warn || pwned_count > min_password_matches" do
+      user = valid_password_user
+
+      # *not* pwned_count > min_password_matches_warn
+      password = "password"
+      user.update password: password, password_confirmation: password
+      User.min_password_matches_warn = 999_999_999
+      assert user.valid?
+      assert_not user.pwned_count > User.min_password_matches_warn
+
+      # pwned_count > min_password_matches_warn
+      User.min_password_matches_warn = 1
+      User.min_password_matches      = 999_999_999
+      assert_not user.valid?
+      assert user.pwned_count > User.min_password_matches_warn
+    end
   end
 
-  test "should return a non-zero count for a pwned password" do
+  def pwned_password_user
     password = "password"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert_not_equal user.pwned_count, 0, "User with pwned password should not have a zero count."
+    assert user.errors.size > 0
+    user
   end
 
-  test "should return a count of zero for a password not in the dataset" do
-    # This test will be unavoidably flaky
+  def valid_password_user
     password = "fddkasnsdddghjt"
     user = User.create email: "example@example.org", password: password, password_confirmation: password
-    assert_equal user.pwned_count, 0, "User with password not in the dataset should have a zero count."
+    assert_equal 0, user.errors.size
+    user
   end
 end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def after_sign_in_path_for(resource)
+    set_flash_message! :alert, :warn_pwned if resource.respond_to?(:pwned?) && resource.pwned?
+    super
+  end
 end

--- a/test/dummy/app/controllers/home_controller.rb
+++ b/test/dummy/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -2,5 +2,6 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :pwned_password
+         :recoverable, :rememberable, :trackable, :validatable, :pwned_password,
+         password_length: 8..72
 end

--- a/test/dummy/app/views/home/index.html.erb
+++ b/test/dummy/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Home#index</h1>
+<p>Find me in app/views/home/index.html.erb</p>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -1,14 +1,23 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Dummy</title>
-    <%= csrf_meta_tags %>
+<head>
+  <title>Dummy</title>
+  <%= csrf_meta_tags %>
 
-    <%= stylesheet_link_tag    'application', media: 'all' %>
-    <%= javascript_include_tag 'application' %>
-  </head>
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
+</head>
 
-  <body>
-    <%= yield %>
-  </body>
+<body>
+  <% if current_user %>
+    <%= link_to "Sign out", destroy_user_session_path %>
+  <% else %>
+    <%= link_to "Sign in", new_user_session_path %>
+  <% end %>
+
+  <p class="notice"><%= notice %></p>
+  <p class="alert"><%= alert %></p>
+
+  <%= yield %>
+</body>
 </html>

--- a/test/dummy/config/initializers/devise.rb
+++ b/test/dummy/config/initializers/devise.rb
@@ -245,7 +245,8 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  #config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/test/dummy/config/initializers/filter_parameter_logging.rb
+++ b/test/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+#Rails.application.config.filter_parameters += [:password]

--- a/test/dummy/config/locales/devise.en.yml
+++ b/test/dummy/config/locales/devise.en.yml
@@ -62,3 +62,6 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      pwned_password:
+        one:   "has appeared in a data breach"
+        other: "has appeared in a data breach %{count} times"

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
+
+  root to: 'home#index'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/test/integration/pwned_password_test.rb
+++ b/test/integration/pwned_password_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class SignUpTest < ActionDispatch::IntegrationTest
+  test "using a valid password" do
+    sign_up_user password: valid_password
+    assert_content 'You have signed up successfully.'
+  end
+
+  test 'submitting password whose length < minimum password length' do
+    sign_up_user password: '123456'
+    assert_content '8 characters minimum'
+  end
+
+  test "using a pwned password" do
+    sign_up_user password: pwned_password
+    assert_content /has appeared in a data breach \d{7,} times/
+  end
+end
+
+class SignInTest < ActionDispatch::IntegrationTest
+  test 'signing in with a valid password' do
+    user = valid_password_user
+    sign_in_user user, password: valid_password
+
+    assert_css '.notice', text: 'Signed in successfully.'
+  end
+
+  test 'signing in with a pwned password' do
+    user = pwned_password_user
+    sign_in_user user, password: pwned_password
+
+    # Shows warning but doesn't prevent them from signing in
+    assert_css '.notice', text: 'Signed in successfully.'
+    assert_css '.alert', text: 'We strongly recommend you change your password.'
+  end
+end
+
+class ChangePasswordTest < ActionDispatch::IntegrationTest
+  test 'changing to a valid password' do
+    user = valid_password_user
+    sign_in_user user, password: valid_password
+    change_password current: valid_password, new: "#{valid_password}2"
+    assert_content 'has been updated successfully'
+  end
+
+  test 'changing to a pwned password' do
+    user = valid_password_user
+    sign_in_user user, password: valid_password
+    change_password current: valid_password, new: pwned_password
+    assert_content /has appeared in a data breach \d{7,} times/
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -1,0 +1,31 @@
+module Factories
+  def create_user(password:)
+    user = User.create(email: "example@example.org", password: password, password_confirmation: password)
+    user.save(validate: false)
+    user
+  end
+
+  def pwned_password
+    'password'
+  end
+
+  def pwned_password_user
+    user = create_user(password: pwned_password)
+    #puts %(user.errors.messages=#{(user.errors.messages).inspect})
+    user
+  end
+
+  def valid_password
+    'fddkasnsdddghjt'
+  end
+
+  def valid_password_user
+    user = create_user(password: valid_password)
+    assert_equal 0, user.errors.size
+    user
+  end
+end
+
+class ActiveSupport::TestCase
+  include Factories
+end

--- a/test/support/integration_test.rb
+++ b/test/support/integration_test.rb
@@ -1,0 +1,54 @@
+# Configure capybara for integration testing
+require 'capybara/rails'
+require 'capybara/minitest'
+Capybara.default_driver   = :rack_test
+Capybara.default_selector = :css
+
+class ActionDispatch::IntegrationTest
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+  include Rails.application.routes.url_helpers
+  include Warden::Test::Helpers
+
+  def setup
+    super
+  end
+
+  def teardown
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+
+  def sign_up_user(password:)
+    visit new_user_registration_path
+
+    #puts page.html
+    fill_in 'Email', with: 'new_user@test.com'
+    fill_in 'Password',              with: password
+    fill_in 'Password confirmation', with: password
+
+    click_button 'Sign up'
+  end
+
+  def sign_in_user(user, password:)
+    visit new_user_session_path
+    assert_equal current_path, '/users/sign_in'
+
+    fill_in 'Email',    with: user.email
+    fill_in 'Password', with: password
+
+    click_button 'Log in'
+    user
+  end
+
+  def change_password(current:, new:)
+    visit edit_user_registration_path
+
+    #puts page.html
+    fill_in 'Current password',      with: current
+    fill_in 'Password',              with: new
+    fill_in 'Password confirmation', with: new
+
+    click_button 'Update'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 require "rails/test_help"
 
+require 'minitest/mock'
+
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+Bundler.require :development
+
 require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 require "rails/test_help"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db
 require "rails/test_help"
 
 require 'minitest/mock'
+require 'capybara/dsl'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
@@ -21,3 +22,13 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
   ActiveSupport::TestCase.fixtures :all
 end
+
+class ActiveSupport::TestCase
+  def setup
+    super
+    User.min_password_matches = 1
+    User.min_password_matches_warn = nil
+  end
+end
+
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
And move all documentation about the warning to its own section to be clearer.

#32

You can preview the doc changes here: https://github.com/TylerRick/devise-pwned_password/tree/improve_docs_regarding_warning