### PR TITLE
Don't require ActiveRecord

### DIFF
--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -15,7 +15,7 @@ module Devise
 
       included do
         validate :not_pwned_password,
-          if: (defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("5.1.x")) ? :will_save_change_to_encrypted_password? : :encrypted_password_changed?
+          if: respond_to?(:will_save_change_to_encrypted_password?) ? :will_save_change_to_encrypted_password? : :encrypted_password_changed?
       end
 
       module ClassMethods


### PR DESCRIPTION
The existing way to decide what method to look at as a condition to validation had 2 issues:
1. If a project weren't using `ActiveRecord` it couldn't use the method `will_save_change_to_encrypted_password?` However projects with a mongo database will be supporting this from version 8.1.0 https://jira.mongodb.com/browse/MONGOID-4528
2. If a project uses multiple databases. Eg. one using `ActiveRecord` and another using mongo before version 8.1.0. In this case `ActiveRecord` would be defined, however not on the model if the user model (`resource`) is a mongo based model. It would throw an error of undefined method.

The simple fix is to just check that the method exists.

Test passes with the fix:
```
devise-pwned_password % bin/test
Run options: --seed 898

# Running:

...........

Finished in 2.609481s, 4.2154 runs/s, 11.1133 assertions/s.
11 runs, 29 assertions, 0 failures, 0 errors, 0 skips
```

Thanks for creating and maintaining the gem.