### PR TITLE
Fix tests by stubbing Pwned API

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,3 +32,18 @@ class ActiveSupport::TestCase
 end
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+
+# Stub network calls to the Pwned Passwords service so tests
+# don't rely on external connectivity. Any password equal to
+# 'password' will be treated as pwned with a high count while
+# others will be considered safe.
+module Pwned
+  class Password
+    def pwned_count
+      @pwned_count ||= (password == 'password' ? 1_000_000 : 0)
+    end
+    def pwned?
+      pwned_count > 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- stub Pwned::Password in tests to avoid network

## Testing
- `RBENV_VERSION=2.6.10 bin/test`

------
https://chatgpt.com/codex/tasks/task_e_683fd103ec2083298a7793c8de2d8347