### PR TITLE
Support Devise 4 and 5, update test environment to Rails 7.1 / Ruby 3.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,15 +7,23 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby-version: ["3.1", "3.2", "3.3"]
+        devise-version: ["~> 4.0", "~> 5.0"]
+
+    env:
+      DEVISE_VERSION: ${{ matrix.devise-version }}
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
+    - uses: actions/checkout@v4
+    - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.10
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
     - name: Build and test with Rake
       run: |
         sudo apt-get install libsqlite3-dev
-        gem install bundler -v 2.4.22
         bundle install --jobs 4 --retry 3
         bin/test

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,4 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
-gem "devise", "~> 4"
+gem "devise", ENV.fetch("DEVISE_VERSION", "~> 5")

--- a/devise-pwned_password.gemspec
+++ b/devise-pwned_password.gemspec
@@ -18,12 +18,15 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "devise", "~> 4"
+  s.add_dependency "devise", ">= 4", "< 6"
   s.add_dependency "pwned", "~> 2.4"
 
   s.add_development_dependency "byebug"
   s.add_development_dependency "capybara"
-  s.add_development_dependency "rails", "~> 5.1.2"
+  s.add_development_dependency "minitest", "< 6.0"
+  s.add_development_dependency "minitest-mock"
+  s.add_development_dependency "ostruct"
+  s.add_development_dependency "rails", "~> 7.1"
   s.add_development_dependency "rubocop", "~> 0.52.1"
   s.add_development_dependency "sqlite3"
 end

--- a/lib/devise/pwned_password/version.rb
+++ b/lib/devise/pwned_password/version.rb
@@ -2,6 +2,6 @@
 
 module Devise
   module PwnedPassword
-    VERSION = "0.1.12"
+    VERSION = "0.2.0"
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -8,7 +8,7 @@ require "devise/pwned_password"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 7.1
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/test/dummy/config/initializers/assets.rb
+++ b/test/dummy/config/initializers/assets.rb
@@ -1,14 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
-
-# Add additional assets to the asset load path.
-# Rails.application.config.assets.paths << Emoji.images_path
-# Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in the app/assets
-# folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+# Rails >= 7.0 does not require asset pipeline configuration here.


### PR DESCRIPTION
## Summary

- Broaden `devise` dependency from `~> 4` to `>= 4, < 6` so existing users on Devise 4 are not broken, while adding support for Devise 5
- CI matrix now tests all combinations of Ruby 3.1/3.2/3.3 × Devise 4/5 (6 jobs total), confirmed passing locally
- Update test environment from Rails 5.1 / Ruby 2.6 to Rails 7.1 / Ruby 3.x
- Bump version to 0.2.0

## Changes

- `devise-pwned_password.gemspec`: `devise >= 4, < 6`; `rails ~> 7.1`; add `minitest < 6.0`, `minitest-mock`, `ostruct` for Ruby 3.x compatibility
- `Gemfile`: use `DEVISE_VERSION` env var (defaults to `~> 5`) so CI can vary the version under test
- `.github/workflows/ruby.yml`: `actions/checkout@v4`; Ruby 3.1/3.2/3.3 × Devise 4/5 matrix; drop pinned bundler version
- `test/dummy/config/application.rb`: `config.load_defaults 7.1`
- `test/dummy/config/initializers/assets.rb`: remove stale Rails 5 Sprockets config

## Test plan

- [x] `bin/test` passes with `DEVISE_VERSION="~> 4.0"` (11 runs, 0 failures)
- [x] `bin/test` passes with `DEVISE_VERSION="~> 5.0"` (11 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)