### PR TITLE
Add Docker test environment and improve test coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+*.gem
+pkg/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:3.3
+
+RUN apt-get update && apt-get install -y libsqlite3-dev
+
+WORKDIR /app
+COPY Gemfile devise-pwned_password.gemspec ./
+COPY lib/devise/pwned_password/version.rb lib/devise/pwned_password/
+
+RUN bundle install --jobs 4 --retry 3
+
+COPY . .
+
+# Re-run bundle install if DEVISE_VERSION is set to a different version
+CMD if [ -n "$DEVISE_VERSION" ]; then bundle install --jobs 4 --retry 3; fi && bin/test

--- a/README.md
+++ b/README.md
@@ -183,8 +183,23 @@ To contribute:
 * Check the [issue tracker](https://github.com/michaelbanfield/devise-pwned_password/issues) and [pull requests](https://github.com/michaelbanfield/devise-pwned_password/pulls) for anything similar
 * Fork the repository
 * Make your changes
-* Run `bin/test` to make sure the unit tests still run
+* Run tests to make sure they still pass (see below)
 * Send a pull request
+
+### Running Tests
+
+You can run tests locally with `bin/test`, or use Docker to match the CI environment:
+
+```bash
+# Build the test image
+docker build -t devise-pwned-test .
+
+# Run tests with Devise 5 (default)
+docker run --rm devise-pwned-test
+
+# Run tests with Devise 4
+docker run --rm -e DEVISE_VERSION="~> 4.0" devise-pwned-test
+```
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/devise/pwned_password/model.rb
+++ b/lib/devise/pwned_password/model.rb
@@ -63,8 +63,6 @@ module Devise
           # This deliberately silently swallows errors and returns false (valid) if there was an error. Most apps won't want to tie the ability to sign up users to the availability of a third-party API.
           return false
         end
-
-        false
       end
 
       private

--- a/test/devise/pwned_password_test.rb
+++ b/test/devise/pwned_password_test.rb
@@ -21,6 +21,30 @@ class Devise::PwnedPassword::Test < ActiveSupport::TestCase
     end
   end
 
+  class WhenPwnedError < Devise::PwnedPassword::Test
+    test "password_pwned? returns false when Pwned::Error is raised" do
+      user = valid_password_user
+      mock_password = Minitest::Mock.new
+      mock_password.expect(:pwned_count, nil) { raise Pwned::Error, "network error" }
+      Pwned::Password.stub :new, mock_password do
+        assert_equal false, user.password_pwned?(valid_password)
+      end
+    end
+  end
+
+  class PwnedAccessor < Devise::PwnedPassword::Test
+    test "pwned? is false before password_pwned? called" do
+      user = User.new
+      assert_equal false, user.pwned?
+    end
+
+    test "pwned? reflects result after password_pwned? called" do
+      user = valid_password_user
+      user.password_pwned?(pwned_password)
+      assert user.pwned?
+    end
+  end
+
   class WhenNotPwned < Devise::PwnedPassword::Test
     test "should accept validation and set pwned_count" do
       user = valid_password_user

--- a/test/integration/pwned_password_test.rb
+++ b/test/integration/pwned_password_test.rb
@@ -33,6 +33,15 @@ class SignInTest < ActionDispatch::IntegrationTest
     assert_css '.notice', text: 'Signed in successfully.'
     assert_css '.alert', text: 'We strongly recommend you change your password.'
   end
+
+  test 'signing in with check_on_sign_in disabled shows no warning' do
+    User.pwned_password_check_on_sign_in = false
+    user = pwned_password_user
+    sign_in_user user, password: pwned_password
+
+    assert_css '.notice', text: 'Signed in successfully.'
+    assert_no_text 'We strongly recommend you change your password.'
+  end
 end
 
 class ChangePasswordTest < ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,7 @@ class ActiveSupport::TestCase
     super
     User.min_password_matches = 1
     User.min_password_matches_warn = nil
+    User.pwned_password_check_on_sign_in = true
   end
 end
 


### PR DESCRIPTION
## Summary

- Add Dockerfile and .dockerignore for containerized testing matching CI environment
- Remove unreachable dead code in model.rb (line 67 after rescue block)
- Add test coverage for API error handling (Pwned::Error fail-open behavior)
- Add tests for `pwned?` accessor state
- Add integration test for `pwned_password_check_on_sign_in=false` configuration
- Reset `pwned_password_check_on_sign_in` in test setup to prevent test pollution
- Update README with Docker test instructions

## Test plan

- [x] All 15 tests pass with Devise 5 (default)
- [x] All 15 tests pass with Devise 4 (`docker run --rm -e DEVISE_VERSION="~> 4.0" devise-pwned-test`)
- [x] Docker build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)